### PR TITLE
修改evaluation.py:防止没有检测出某些类的时候evalution运行出错

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -306,8 +306,14 @@ def evaluation(detoutput, imageset, annopath, classnames):
     #             'basketball-court', 'storage-tank',  'soccer-ball-field', 'roundabout', 'harbor', 'swimming-pool', 'helicopter', ']
     classaps = []
     map = 0
+    skippedClassCount = 0
     for classname in classnames:
         print('classname:', classname)
+        detfile = detpath.format(classname)
+        if not (os.path.exists(detfile)):
+            skippedClassCount += 1
+            print('测试集中未找到:{:s}'.format(classname))
+            continue
         rec, prec, ap = voc_eval(detpath,
              annopath,
              imagesetfile,
@@ -325,7 +331,7 @@ def evaluation(detoutput, imageset, annopath, classnames):
         # plt.ylabel('precision')
         # plt.plot(rec, prec)
        # plt.show()
-    map = map/len(classnames)
+    map = map/(len(classnames)-skippedClassCount)
     print('map:', map)
     classaps = 100*np.array(classaps)
     print('classaps: ', classaps)


### PR DESCRIPTION
当检测出来的类中没有一些类的时候，就会报如下的错误
```
检测结果已merge
检测结果已按照类别分类
校验数据集名称文件已生成
classname: harbor
Traceback (most recent call last):
  File "/tmp/pycharm_project_389/evaluation.py", line 360, in <module>
    evaluation(
  File "/tmp/pycharm_project_389/evaluation.py", line 316, in evaluation
    rec, prec, ap = voc_eval(detpath,
  File "/tmp/pycharm_project_389/evaluation.py", line 125, in voc_eval
    with open(imagesetfile, 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/test/Persons/hukaixuan/yolov5_DOTA_OBB/DOTA_demo_view/detection/result_txt/imgnamefile.txt'

Process finished with exit code 1
```
修改的部分主要是如果没有生成对应类的文件，就跳过它。同时计数，并在算map的时候分母减去跳过的类。